### PR TITLE
fix(docu): Documentation/examples update

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
     bReq.requestedMaxReferencesPerNode = 0;
     bReq.nodesToBrowse = UA_BrowseDescription_new();
     bReq.nodesToBrowseSize = 1;
-    /* In case the NodeId is identified by a string or bytestring, make a dinamically
+    /* In case the NodeId is identified by a string or bytestring, make a dynamically
        allocated copy of it (UA_NodeId_copy(..., &breq.nodesToBrowse[0].nodeId)). */
     bReq.nodesToBrowse[0].nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER); /* browse objects folder */
     bReq.nodesToBrowse[0].resultMask = UA_BROWSERESULTMASK_ALL; /* return everything */

--- a/examples/client.c
+++ b/examples/client.c
@@ -72,6 +72,8 @@ int main(int argc, char *argv[]) {
     bReq.requestedMaxReferencesPerNode = 0;
     bReq.nodesToBrowse = UA_BrowseDescription_new();
     bReq.nodesToBrowseSize = 1;
+    /* In case the NodeId is identified by a string or bytestring, make a dinamically
+       allocated copy of it (UA_NodeId_copy(..., &breq.nodesToBrowse[0].nodeId)). */
     bReq.nodesToBrowse[0].nodeId = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER); /* browse objects folder */
     bReq.nodesToBrowse[0].resultMask = UA_BROWSERESULTMASK_ALL; /* return everything */
     UA_BrowseResponse bResp = UA_Client_Service_browse(client, bReq);


### PR DESCRIPTION
Documentation/examples update [Segmentation fault occurs when clearing
a browse request for a stack allocated NodeId]. See also
https://github.com/open62541/open62541/issues/6777.